### PR TITLE
Images from specific views feature

### DIFF
--- a/src/settings_panel.cpp
+++ b/src/settings_panel.cpp
@@ -17,18 +17,18 @@ SettingsPanel::SettingsPanel(QWidget * parent)
   float start_dot_size = 0.1;
   float start_sphere_size = 0.2;
 
-  settings_msg_ = vinspect_msgs::msg::Settings();
-  settings_msg_.transparency = 0.5;
-  settings_msg_.dot_size = start_dot_size;
-  settings_msg_.sphere_radius = start_sphere_size;
-  settings_msg_.mean_min_max = vinspect_msgs::msg::Settings::MEAN;
-  settings_msg_.custom_color = false;
-  settings_msg_.resume = false;
-  settings_msg_.pause = false;
-  settings_msg_.clear = false;
+  sparse_settings_msg_ = vinspect_msgs::msg::Settings();
+  sparse_settings_msg_.transparency = 0.5;
+  sparse_settings_msg_.dot_size = start_dot_size;
+  sparse_settings_msg_.sphere_radius = start_sphere_size;
+  sparse_settings_msg_.mean_min_max = vinspect_msgs::msg::Settings::MEAN;
+  sparse_settings_msg_.custom_color = false;
+  sparse_settings_msg_.resume = false;
+  sparse_settings_msg_.pause = false;
+  sparse_settings_msg_.clear = false;
 
   // Creates a vertical box layout
-  QVBoxLayout * sparse_layout = new QVBoxLayout(this); 
+  QVBoxLayout * sparse_layout = new QVBoxLayout(this);
 
   // Transparency slider
   sparse_layout->addWidget(new QLabel("Transparency:"));
@@ -39,7 +39,7 @@ SettingsPanel::SettingsPanel(QWidget * parent)
   transparency_slider_->setSingleStep(1);
   transparency_slider_->setTracking(false);
   // slider scale is in 0-100 not 0-1
-  transparency_slider_->setValue(settings_msg_.transparency * 100);
+  transparency_slider_->setValue(sparse_settings_msg_.transparency * 100);
   sparse_layout->addWidget(transparency_slider_);
   connect(transparency_slider_, SIGNAL(valueChanged(int)), this, SLOT(onTransparencyChange(int)));
 
@@ -170,6 +170,16 @@ SettingsPanel::SettingsPanel(QWidget * parent)
   connect(service_stop_button, &QPushButton::clicked, [this] {requestStopClick();});
   dense_layout->addWidget(service_stop_button, 12, 0, 1, 2);
 
+  QWidget * horizontalLineWidget4 = new QWidget;
+  horizontalLineWidget4->setFixedHeight(2);
+  horizontalLineWidget4->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  horizontalLineWidget4->setStyleSheet(QString("background-color: #c0c0c0;"));
+  dense_layout->addWidget(horizontalLineWidget4, 13, 0, 1, 2);
+
+  QPushButton * dense_req_button = new QPushButton("Get dense data at pose");
+  connect(dense_req_button, &QPushButton::clicked, [this] {dense_req_Click();});
+  dense_layout->addWidget(dense_req_button, 15, 0, 1, 2);
+
   // make tab layout of sparse and dense
   QTabWidget * tabWidget = new QTabWidget(this);
   auto sparse_widget = new QWidget;
@@ -186,16 +196,18 @@ void SettingsPanel::load(const rviz_common::Config & conf) {rviz_common::Panel::
 
 void SettingsPanel::onInitialize()
 {
-  requester_node_ = getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
+  plugin_node_ = getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
   rclcpp::QoS latching_qos = rclcpp::QoS(1).transient_local();
-  requester_publisher_ = requester_node_->create_publisher<vinspect_msgs::msg::Settings>(
+  settings_publisher_ = plugin_node_->create_publisher<vinspect_msgs::msg::Settings>(
     "vinspect/settings", latching_qos);
   // publish settings message once with latching
-  requester_publisher_->publish(settings_msg_);
-  start_client_ = requester_node_->create_client<vinspect_msgs::srv::StartReconstruction>(
+  settings_publisher_->publish(sparse_settings_msg_);
+  start_client_ = plugin_node_->create_client<vinspect_msgs::srv::StartReconstruction>(
     "/vinspect/start_reconstruction");
   stop_client_ =
-    requester_node_->create_client<std_srvs::srv::Empty>("/vinspect/stop_reconstruction");
+    plugin_node_->create_client<std_srvs::srv::Empty>("/vinspect/stop_reconstruction");
+  dense_req_publisher_ = plugin_node_->create_publisher<std_msgs::msg::String>(
+    "vinspect/dense_data_req", latching_qos);
 }
 
 
@@ -212,12 +224,12 @@ void SettingsPanel::onMeanButtonClick(const QString & text)
   } else if (text.toStdString() == "Max") {
     new_mean_min_max = vinspect_msgs::msg::Settings::MAX;
   } else {
-    RCLCPP_ERROR(requester_node_->get_logger(), "Mean/Min/Max not recognized");
+    RCLCPP_ERROR(plugin_node_->get_logger(), "Mean/Min/Max not recognized");
     return;
   }
-  if (new_mean_min_max != settings_msg_.mean_min_max) {
-    settings_msg_.mean_min_max = new_mean_min_max;
-    requester_publisher_->publish(settings_msg_);
+  if (new_mean_min_max != sparse_settings_msg_.mean_min_max) {
+    sparse_settings_msg_.mean_min_max = new_mean_min_max;
+    settings_publisher_->publish(sparse_settings_msg_);
   }
 }
 
@@ -229,12 +241,12 @@ void SettingsPanel::onColorButtonClick(const QString & text)
   } else if (text.toStdString() == "On") {
     new_color = true;
   } else {
-    RCLCPP_ERROR(requester_node_->get_logger(), "Color not recognized");
+    RCLCPP_ERROR(plugin_node_->get_logger(), "Color not recognized");
     return;
   }
-  if (new_color != settings_msg_.custom_color) {
-    settings_msg_.custom_color = new_color;
-    requester_publisher_->publish(settings_msg_);
+  if (new_color != sparse_settings_msg_.custom_color) {
+    sparse_settings_msg_.custom_color = new_color;
+    settings_publisher_->publish(sparse_settings_msg_);
   }
 }
 
@@ -242,9 +254,9 @@ void SettingsPanel::onDotSizeChange(const std::string & text)
 {
   std::cout << "Dot size changed to " << text << std::endl;
   double value = std::stod(text);
-  if (value != settings_msg_.dot_size) {
-    settings_msg_.dot_size = value;
-    requester_publisher_->publish(settings_msg_);
+  if (value != sparse_settings_msg_.dot_size) {
+    sparse_settings_msg_.dot_size = value;
+    settings_publisher_->publish(sparse_settings_msg_);
   }
 }
 
@@ -252,9 +264,9 @@ void SettingsPanel::onSphereSizeChange(const std::string & text)
 {
   std::cout << "Sphere size changed to " << text << std::endl;
   double value = std::stod(text);
-  if (value != settings_msg_.sphere_radius) {
-    settings_msg_.sphere_radius = value;
-    requester_publisher_->publish(settings_msg_);
+  if (value != sparse_settings_msg_.sphere_radius) {
+    sparse_settings_msg_.sphere_radius = value;
+    settings_publisher_->publish(sparse_settings_msg_);
   }
 }
 
@@ -266,31 +278,31 @@ void SettingsPanel::onTransparencyChange(int value)
   float value_f = static_cast<float>(value);
   // Not allowed to have a Value of 0, value is needed between 0 and 1
   float transparency = ((value_f + 1) / 100);
-  if (transparency != settings_msg_.transparency) {
-    settings_msg_.transparency = transparency;
-    requester_publisher_->publish(settings_msg_);
+  if (transparency != sparse_settings_msg_.transparency) {
+    sparse_settings_msg_.transparency = transparency;
+    settings_publisher_->publish(sparse_settings_msg_);
   }
 }
 
 void SettingsPanel::pauseClick()
 {
-  settings_msg_.pause = true;
-  requester_publisher_->publish(settings_msg_);
-  settings_msg_.pause = false;
+  sparse_settings_msg_.pause = true;
+  settings_publisher_->publish(sparse_settings_msg_);
+  sparse_settings_msg_.pause = false;
 }
 
 void SettingsPanel::resumeClick()
 {
-  settings_msg_.resume = true;
-  requester_publisher_->publish(settings_msg_);
-  settings_msg_.resume = false;
+  sparse_settings_msg_.resume = true;
+  settings_publisher_->publish(sparse_settings_msg_);
+  sparse_settings_msg_.resume = false;
 }
 
 void SettingsPanel::clearSparseClick()
 {
-  settings_msg_.clear = true;
-  requester_publisher_->publish(settings_msg_);
-  settings_msg_.clear = false;
+  sparse_settings_msg_.clear = true;
+  settings_publisher_->publish(sparse_settings_msg_);
+  sparse_settings_msg_.clear = false;
 }
 
 void SettingsPanel::requestStartClick()
@@ -309,7 +321,7 @@ void SettingsPanel::requestStartClick()
       auto result = future.get();
       auto x = result ? "true" : "false";
       std::cout << x << std::endl;
-      RCLCPP_INFO(requester_node_->get_logger(), x);
+      RCLCPP_INFO(plugin_node_->get_logger(), x);
     };
   auto future_result = start_client_->async_send_request(request, response_received_callback);
 }
@@ -323,7 +335,7 @@ void SettingsPanel::requestStopClick()
       auto result = future.get();
       auto x = result ? "true" : "false";
       std::cout << x << std::endl;
-      RCLCPP_INFO(requester_node_->get_logger(), x);
+      RCLCPP_INFO(plugin_node_->get_logger(), x);
     };
   auto future_result = stop_client_->async_send_request(request, response_received_callback);
 }
@@ -341,6 +353,13 @@ void SettingsPanel::clearClick(const std::reference_wrapper<QLineEdit *> input_o
   for (int i = 0; i < 4; i++) {
     input_objects[i].get()->setText("");
   }
+}
+
+void SettingsPanel::dense_req_Click()
+{
+  auto message = std_msgs::msg::String();
+  message.data = "request";
+  dense_req_publisher_->publish(message);
 }
 
 SettingsPanel::~SettingsPanel()

--- a/src/settings_panel.hpp
+++ b/src/settings_panel.hpp
@@ -76,11 +76,12 @@ protected:
 
   QLineEdit * file_path_;
 
-  std::shared_ptr<rclcpp::Node> requester_node_;
-  rclcpp::Publisher<vinspect_msgs::msg::Settings>::SharedPtr requester_publisher_;
+  std::shared_ptr<rclcpp::Node> plugin_node_;
+  rclcpp::Publisher<vinspect_msgs::msg::Settings>::SharedPtr settings_publisher_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr dense_req_publisher_;
   rclcpp::Client<vinspect_msgs::srv::StartReconstruction>::SharedPtr start_client_;
   rclcpp::Client<std_srvs::srv::Empty>::SharedPtr stop_client_;
-  vinspect_msgs::msg::Settings settings_msg_;
+  vinspect_msgs::msg::Settings sparse_settings_msg_;
 
 protected Q_SLOTS:
   void onObjectButtonClick(const QString & text);
@@ -96,6 +97,7 @@ protected Q_SLOTS:
   void clearClick(const std::reference_wrapper<QLineEdit *> input_objects[]);
   void requestStartClick();
   void requestStopClick();
+  void dense_req_Click();
 };
 
 }  // namespace plugins

--- a/src/settings_panel.hpp
+++ b/src/settings_panel.hpp
@@ -28,6 +28,7 @@
 #include <rviz_common/display_context.hpp>
 #include <rviz_common/panel.hpp>
 #include <std_msgs/msg/string.hpp>
+#include <std_msgs/msg/int32.hpp>
 #include <std_srvs/srv/empty.hpp>
 
 #include "vinspect_msgs/msg/settings.hpp"
@@ -76,9 +77,12 @@ protected:
 
   QLineEdit * file_path_;
 
+   QLineEdit * multi_pose_percentage;
+
   std::shared_ptr<rclcpp::Node> plugin_node_;
   rclcpp::Publisher<vinspect_msgs::msg::Settings>::SharedPtr settings_publisher_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr dense_req_publisher_;
+  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr dense_available_poses_publisher_;
   rclcpp::Client<vinspect_msgs::srv::StartReconstruction>::SharedPtr start_client_;
   rclcpp::Client<std_srvs::srv::Empty>::SharedPtr stop_client_;
   vinspect_msgs::msg::Settings sparse_settings_msg_;
@@ -97,7 +101,8 @@ protected Q_SLOTS:
   void clearClick(const std::reference_wrapper<QLineEdit *> input_objects[]);
   void requestStartClick();
   void requestStopClick();
-  void dense_req_Click();
+  void denseReqClick();
+  void denseAvailablePosesClick();
 };
 
 }  // namespace plugins


### PR DESCRIPTION
This PR is part of a larger feature for Vinspect across multiple repositories.
Relevant PRs: DLR-MO/vinspect_ros2#1, DLR-MO/vinspect#1

These specific changes are mostly about: 

- renaming to better clarify dense and sparse functionality 
- adding functionality in the plugins to request an image from a specific view. 